### PR TITLE
Workaround for object having recurrent ID change

### DIFF
--- a/core/class/rflink.class.php
+++ b/core/class/rflink.class.php
@@ -446,6 +446,19 @@ class rflink extends eqLogic {
 
     $rflink = self::byLogicalId($nodeid, 'rflink');
 
+    // Check if this sensor is known
+    if (!is_object($rflink))
+     {
+        // If not look for a generic one (ID:*) and use it if found
+        $nodeid_generic = $protocol . '_*';
+        $rflink_generic = self::byLogicalId($nodeid_generic, 'rflink');
+        if (is_object($rflink_generic))
+        {
+          $rflink = $rflink_generic;
+          $nodeid = $nodeid_generic;
+        }
+     }
+
     if (!is_object($rflink) && config::byKey('include_mode', 'rflink') == '1') {
       $rflink = new rflink();
       $rflink->setEqType_name('rflink');


### PR DESCRIPTION
I propose this pull request to solve the recurring problem of objects constantly changing ID: after a battery change or even an internal reboot without any actions on the object.

This trick is activated only if one ID with <Protocol>_* exist, it has not effect otherwise.

If an ID with <Protocol>_* exist, it matches any ID for this protocol
example: Auriol V3_* will match Auriol V3_1001 -> Auriol V3_A901 ->
Auriol V3_13E01, … 
Unless a device with the exact match is created/already exist, in such a case the exact match take the priority.

I'm running this version for several months, it solved perfectly the issue.

I took the code from a proposal from sbeuzit in the forum.  