### PR TITLE
fix pour faire fonctionner le statut des interrupteurs somfy RTS

### DIFF
--- a/core/class/rflink.class.php
+++ b/core/class/rflink.class.php
@@ -206,7 +206,7 @@ class rflink extends eqLogic {
     public function registerRTS($_cmd, $_value) {
         //checkCmdOk($_id, $_name, $_subtype, $_value)
         //checkActOk($_id, $_name, $_subtype, $_cmdid, $_request, $_maxslider)
-        $this->checkCmdOk($_cmd, 'Statut ' . $_cmd, 'binary', $_value);
+        $this->checkCmdOk($_cmd, 'Statut ' . $_cmd, 'string', $_value);
         $this->checkAndUpdateCmd($_cmd, $_value);
         $this->checkActOk('PAIR' . $_cmd, 'Appairement ' . $_cmd, $_cmd, 'PAIR', '0');
         $this->checkActOk('UP' . $_cmd, 'Montée ' . $_cmd, $_cmd, 'UP', 'UP', '0');


### PR DESCRIPTION
Les statuts des interrupteurs ne sont pas du binaire. sur mes interrupteurs j'ai les statuts DOWN / UP / STOP.
Je ne suis pas expert sur le domaine, mais je pense qu’en RTS, on peut rester avec un string plutôt qu'un binaire.

Et merci pour ton travail!